### PR TITLE
[FUSE-95] - Fix logic code of genderFilter with admin, trainer and customer

### DIFF
--- a/apps/weight-loss-consultant-gateway/src/app/services/authentication/authentication.service.ts
+++ b/apps/weight-loss-consultant-gateway/src/app/services/authentication/authentication.service.ts
@@ -52,7 +52,7 @@ export class AuthenticationService {
 
   async loginWithFirebase(firebaseUserToken: any): Promise<any> {
     const pattern = {cmd: GOOGLE_FIREBASE_AUTHENTICATE_USER}
-    return this.authenticationServiceProxy.send<any, any>(pattern, firebaseUser)
+    return this.authenticationServiceProxy.send<any, any>(pattern, firebaseUserToken)
       // .toPromise<any>();
       .toPromise();
     return this.authenticationServiceProxy.send<any, any>(pattern, firebaseUserToken).toPromise();

--- a/apps/weight-loss-consultant-users-mgnt-api/src/app/services/sorting-filtering.service.ts
+++ b/apps/weight-loss-consultant-users-mgnt-api/src/app/services/sorting-filtering.service.ts
@@ -46,17 +46,15 @@ export class SortingAndFilteringService {
       }
       default: {
         const result = await this.adminRepository.createQueryBuilder("admin")
-          .where("admin.gender = :gender", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE})
-          .andWhere("admin.fullname like :fullname", {fullname : `%${searchValue}%`})
-          .orWhere("admin.email like :email", {email: `%${searchValue}%`})
+          .where("admin.gender = :gender AND (admin.fullname like :fullname)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, fullname : `%${searchValue}%`})
+          .orWhere("admin.gender = :gender AND (admin.email like :email)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, email: `%${searchValue}%`})
           .orderBy(sortBy, order === "ASC" ? "ASC" : "DESC")
           .offset(skipped)
           .limit(limit)
           .getMany()
         const totalCount = await this.adminRepository.createQueryBuilder("admin")
-          .where("admin.gender = :gender", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE})
-          .andWhere("admin.fullname like :fullname", {fullname : `%${searchValue}%`})
-          .orWhere("admin.email like :email", {email: `%${searchValue}%`})
+          .where("admin.gender = :gender AND (admin.fullname like :fullname)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, fullname : `%${searchValue}%`})
+          .orWhere("admin.gender = :gender AND (admin.email like :email)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, email: `%${searchValue}%`})
           .getCount();
         const res = await this.mappingResultPaginate(totalCount, page, limit, result);
         return res;
@@ -88,18 +86,16 @@ export class SortingAndFilteringService {
       default: {
         const result = await this.trainerRepository.createQueryBuilder("trainer")
           .leftJoinAndSelect("trainer.packages", "package")
-          .where("trainer.gender = :gender", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE})
-          .andWhere("trainer.fullname like :fullname", {fullname : `%${searchValue}%`})
-          .orWhere("trainer.email like :email", {email: `%${searchValue}%`})
+          .where("trainer.gender = :gender AND (trainer.fullname like :fullname)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, fullname : `%${searchValue}%`})
+          .orWhere("trainer.gender = :gender AND (trainer.email like :email)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, email: `%${searchValue}%`})
           .orderBy(sortBy, order === "ASC" ? "ASC" : "DESC")
           .offset(skipped)
           .limit(limit)
           .getMany()
         const totalCount = await this.trainerRepository.createQueryBuilder("trainer")
-          .where("trainer.gender = :gender", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE})
-          .andWhere("trainer.fullname like :fullname", {fullname : `%${searchValue}%`})
-          .orWhere("trainer.email like :email", {email: `%${searchValue}%`})
           .leftJoinAndSelect("trainer.packages", "package")
+          .where("trainer.gender = :gender AND (trainer.fullname like :fullname)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, fullname : `%${searchValue}%`})
+          .orWhere("trainer.gender = :gender AND (trainer.email like :email)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, email: `%${searchValue}%`})
           .getCount();
         const res = await this.mappingResultPaginate(totalCount, page, limit, result);
         return res;
@@ -129,18 +125,16 @@ export class SortingAndFilteringService {
       }
       default: {
         const result = await this.customerRepository.createQueryBuilder("customer")
-          .where("customer.gender = :gender", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE})
-          .andWhere("customer.fullname like :fullname", {fullname : `%${searchValue}%`})
-          .orWhere("customer.email like :email", {email: `%${searchValue}%`})
+          .where("customer.gender = :gender AND (customer.fullname like :fullname)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, fullname : `%${searchValue}%`})
+          .orWhere("customer.gender = :gender AND (customer.email like :email)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, email: `%${searchValue}%`})
           .leftJoinAndSelect("customer.campaigns", "campaign")
           .orderBy(sortBy, order === "ASC" ? "ASC" : "DESC")
           .offset(skipped)
           .limit(limit)
           .getMany()
         const totalCount = await this.customerRepository.createQueryBuilder("customer")
-          .where("customer.gender = :gender", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE})
-          .andWhere("customer.fullname like :fullname", {fullname : `%${searchValue}%`})
-          .orWhere("customer.email like :email", {email: `%${searchValue}%`})
+          .where("customer.gender = :gender AND (customer.fullname like :fullname)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, fullname : `%${searchValue}%`})
+          .orWhere("customer.gender = :gender AND (customer.email like :email)", {gender: genderFilter === "1" ? Gender.MALE : Gender.FEMALE, email: `%${searchValue}%`})
           .leftJoinAndSelect("customer.campaigns", "campaign")
           .getCount();
         const res = await this.mappingResultPaginate(totalCount, page, limit, result);


### PR DESCRIPTION
- Gender Filter is not working on get all Admin, Trainer, Customer.
- Solution: edit logic code of queryBuilder
- Result:
- get all admins:
![image](https://user-images.githubusercontent.com/62231837/137628259-99aaed7b-88fe-47ff-9f34-8f888cb24c2e.png)
-get all admins have gender is 1 (Male)
![image](https://user-images.githubusercontent.com/62231837/137628285-f10fc435-283a-43d3-aa9a-981d44fc5aa2.png)
- get all admins have gender is 2 (Female)
![image](https://user-images.githubusercontent.com/62231837/137628311-af4c98ea-a41f-4368-9849-70eb2b347f7b.png)
- get all trainers
![image](https://user-images.githubusercontent.com/62231837/137628343-5f82468c-aacc-4055-81cc-85b0c811841a.png)
- get all trainers have gender is 1 (Male)
![image](https://user-images.githubusercontent.com/62231837/137628361-b25d0dd0-4381-43f9-b492-c3c5a7bf9bd7.png)
- get all trainers have gender is 2 (Female)
![image](https://user-images.githubusercontent.com/62231837/137628378-28db27ad-4446-4639-a5d4-c21f2bc81e4a.png)
- get all customers:
![image](https://user-images.githubusercontent.com/62231837/137628393-36d90885-0bb9-4072-b236-77cf9e0c4ccf.png)
- get all customers have gender is 1 (Male)
![image](https://user-images.githubusercontent.com/62231837/137628408-9278d008-33c2-40db-8c65-085ab70774c9.png)
- get all customers have gender is 2 (Female)
![image](https://user-images.githubusercontent.com/62231837/137628439-6fb55849-bd0e-416b-9bbb-4fdf96809363.png)
